### PR TITLE
Fix newline handling for announcement messages

### DIFF
--- a/commands/announce.js
+++ b/commands/announce.js
@@ -18,6 +18,10 @@ module.exports = {
         const channel = interaction.options.getChannel('channel');
         let message = interaction.options.getString('message');
 
+        // Allow escaped newlines and tabs in the slash command input
+        message = message.replace(/\\n/g, '\n').replace(/\\t/g, '\t');
+
+        // Remove any leading block quote markup
         message = message.replace(/^>>>?\s*/, '');
 
         await channel.send(message);

--- a/commands/eannounce.js
+++ b/commands/eannounce.js
@@ -22,7 +22,10 @@ module.exports = {
     async execute(interaction) {
         const channel = interaction.options.getChannel('channel');
         const title = interaction.options.getString('title');
-        const description = interaction.options.getString('description');
+        let description = interaction.options.getString('description');
+
+        // Allow escaped newlines and tabs for better formatting
+        description = description.replace(/\\n/g, '\n').replace(/\\t/g, '\t');
 
         const embed = new EmbedBuilder()
             .setTitle(title)


### PR DESCRIPTION
## Summary
- allow `\n` and `\t` escapes for `/announce`
- add same newline support for `/eannounce`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d41018dc083209335e413c7068b02