### PR TITLE
Fix newline handling for announcement messages

### DIFF
--- a/commands/announce.js
+++ b/commands/announce.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const { SlashCommandBuilder, ChannelType, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,16 +12,35 @@ module.exports = {
         .addStringOption(option =>
             option.setName('message')
                 .setDescription('The message content')
-                .setRequired(true)),
+                .setRequired(false)),
 
     async execute(interaction) {
         const channel = interaction.options.getChannel('channel');
         let message = interaction.options.getString('message');
 
-        message = message.replace(/^>>>?\s*/, '');
+        if (message) {
+            message = message.replace(/\\n/g, '\n').replace(/\\t/g, '\t');
+            message = message.replace(/^>>>?\s*/, '');
+            await channel.send(message);
+            return interaction.reply({ content: '✅ Announcement sent to channel!' });
+        }
 
-        await channel.send(message);
-        await interaction.reply({ content: '✅ Announcement sent to channel!' });
+        const modalId = `announceModal-${interaction.id}`;
+        const modal = new ModalBuilder()
+            .setCustomId(modalId)
+            .setTitle('Announcement Message');
+
+        const input = new TextInputBuilder()
+            .setCustomId('message')
+            .setLabel('Message')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true);
+
+        modal.addComponents(new ActionRowBuilder().addComponents(input));
+
+        interaction.client.modals.set(modalId, { channelId: channel.id });
+
+        await interaction.showModal(modal);
     }
 
 };

--- a/commands/eannounce.js
+++ b/commands/eannounce.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ChannelType, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -16,21 +16,40 @@ module.exports = {
         .addStringOption(option =>
             option.setName('description')
                 .setDescription('Embed description')
-                .setRequired(true)),
+                .setRequired(false)),
 
 
     async execute(interaction) {
         const channel = interaction.options.getChannel('channel');
         const title = interaction.options.getString('title');
-        const description = interaction.options.getString('description');
+        let description = interaction.options.getString('description');
 
-        const embed = new EmbedBuilder()
-            .setTitle(title)
-            .setDescription(description)
-            .setColor(0x1c949d)
-            .setTimestamp();
+        if (description) {
+            description = description.replace(/\\n/g, '\n').replace(/\\t/g, '\t');
+            const embed = new EmbedBuilder()
+                .setTitle(title)
+                .setDescription(description)
+                .setColor(0x1c949d)
+                .setTimestamp();
+            await channel.send({ embeds: [embed] });
+            return interaction.reply({ content: '✅ Embedded announcement sent!' });
+        }
 
-        await channel.send({ embeds: [embed] });
-        await interaction.reply({ content: '✅ Embedded announcement sent!' });
+        const modalId = `eannounceModal-${interaction.id}`;
+        const modal = new ModalBuilder()
+            .setCustomId(modalId)
+            .setTitle('Embedded Announcement');
+
+        const descInput = new TextInputBuilder()
+            .setCustomId('description')
+            .setLabel('Description')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(true);
+
+        modal.addComponents(new ActionRowBuilder().addComponents(descInput));
+
+        interaction.client.modals.set(modalId, { channelId: channel.id, title });
+
+        await interaction.showModal(modal);
     }
 };


### PR DESCRIPTION
## Summary
- use modals to capture multi-line text for `/announce` and `/eannounce`
- parse escaped newlines and tabs when text is provided directly
- handle modal submissions in `interactionCreate`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d41018dc083209335e413c7068b02